### PR TITLE
[Feat ] 로그인 

### DIFF
--- a/apps/account/serializers.py
+++ b/apps/account/serializers.py
@@ -1,8 +1,10 @@
 from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from apps.account.models import Account
 
 
+# api/v1/accounts/signup
 class SignUpSerializer(serializers.ModelSerializer):
     class Meta:
         model = Account
@@ -14,10 +16,39 @@ class SignUpSerializer(serializers.ModelSerializer):
         extra_kwargs = {"password": {"write_only": True}}
 
     def create(self, validated_data):
-        # email = validated_data.get("email")
-        # nickname = validated_data.get("nickname")
-        # password = validated_data.get("password")
         account = Account.objects.create_user(**validated_data)
         account.set_password(validated_data.get("password"))
         account.save()
         return account
+
+
+# api/v1/accounts/signin
+class SignInSerializer(TokenObtainPairSerializer):
+    class Meta:
+        model = Account
+        fields = [
+            "email",
+            "password",
+        ]
+
+    def validate(self, data):
+        email = data.get("email")
+        password = data.get("password")
+
+        if Account.objects.filter(email=email).exists():
+            account = Account.objects.get(email=email)
+
+            if not account.check_password(password):
+                raise serializers.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")  # 비밀번호 틀림
+        else:
+            raise serializers.ValidationError("아이디 또는 비빌먼호를 잘못 입력했습니다.")  # 아이디 없음
+
+        token = super().get_token(account)
+        access_token = str(token.access_token)
+        refresh_token = str(token)
+
+        data = {
+            "access": access_token,
+            "refresh": refresh_token,
+        }
+        return data

--- a/apps/account/urls.py
+++ b/apps/account/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from apps.account.views import SignUpView
+from apps.account.views import SignInView, SignUpView
 
 urlpatterns = [
     path("signup", SignUpView.as_view()),
+    path("signin", SignInView.as_view()),
 ]

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -2,9 +2,10 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.account.serializers import SignUpSerializer
+from apps.account.serializers import SignInSerializer, SignUpSerializer
 
 
+# api/v1/accounts/signup
 class SignUpView(APIView):
     def post(self, request):
         serializer = SignUpSerializer(data=request.data)
@@ -16,3 +17,17 @@ class SignUpView(APIView):
                 status=status.HTTP_201_CREATED,
             )
         return Response({"message": "회원가입에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+
+# api/v1/accounts/signin
+class SignInView(APIView):
+    def post(self, request):
+        serializer = SignInSerializer(data=request.data)
+
+        if serializer.is_valid():
+            token = serializer.validated_data
+            return Response(token, status=status.HTTP_200_OK)
+        return Response(
+            serializer.errors,
+            status=status.HTTP_400_BAD_REQUEST,
+        )


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- 로그인기능 구현

### Changes

- 


### 특이사항 (Optional)

<img width="780" alt="스크린샷 2022-07-27 오전 12 58 09" src="https://user-images.githubusercontent.com/83942213/181053751-913cbb85-362c-4fac-b7e8-556e37d2337e.png">

- 로그인 시리얼라이저의 유저정보 validate로직에서
- 아이디와 비밀번호를 각각 validate하지만, 
- 보안상의 이점이 있다고 판단하여 response의 메세지는 동일하게 구성하였습니다.

### Screenshots (Optional)


- body에 빈값 입력시
<img width="1481" alt="스크린샷 2022-07-27 오전 12 40 56" src="https://user-images.githubusercontent.com/83942213/181053087-2e5fa5e7-b230-4601-adf9-afeef450d495.png">

- 로그인 성공시
<img width="1465" alt="스크린샷 2022-07-27 오전 12 42 24" src="https://user-images.githubusercontent.com/83942213/181053209-4977149d-43b4-4caa-ad87-b11c79e735e4.png">

- 로그인 실패시
<img width="1466" alt="스크린샷 2022-07-27 오전 12 48 32" src="https://user-images.githubusercontent.com/83942213/181053263-111bb63c-d922-4a6d-9b36-223f34f80b62.png">


