### PR TITLE
[Feat] 회원정보 수정, 삭제

### DIFF
--- a/apps/account/urls.py
+++ b/apps/account/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from apps.account.views import SignInView, SignUpView
+from apps.account.views import AccountView, SignInView, SignUpView
 
 urlpatterns = [
     path("signup", SignUpView.as_view()),
     path("signin", SignInView.as_view()),
+    path("<int:pk>", AccountView.as_view()),
 ]

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -1,8 +1,15 @@
-from rest_framework import status
+from rest_framework import generics, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.account.serializers import SignInSerializer, SignUpSerializer
+from apps.account.models import Account
+from apps.account.serializers import (
+    AccountDeleteSerializer,
+    AccountDetailSerializer,
+    SignInSerializer,
+    SignUpSerializer,
+)
+from apps.utils import IsOwnerOrReadOnly
 
 
 # api/v1/accounts/signup
@@ -26,8 +33,42 @@ class SignInView(APIView):
 
         if serializer.is_valid():
             token = serializer.validated_data
-            return Response(token, status=status.HTTP_200_OK)
+            return Response(
+                {
+                    "message": "로그인 되었습니다.",
+                    "access_token": token["access"],
+                    "refresh_token": token["refresh"],
+                },
+                status=status.HTTP_200_OK,
+            )
         return Response(
             serializer.errors,
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+
+# api/v1/accounts/<int:pk>
+class AccountView(generics.RetrieveUpdateAPIView):
+    permission_classes = [IsOwnerOrReadOnly]
+
+    def get_queryset(self):
+        queryset = Account.objects.filter(is_active=True, pk=self.kwargs["pk"])
+        return queryset
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return AccountDetailSerializer
+        elif self.request.method == "PUT":
+            return AccountDetailSerializer
+        elif self.request.method == "DELETE":
+            return AccountDeleteSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        serializer = self.get_serializer(self.get_object())
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def put(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)

--- a/apps/utils/__init__.py
+++ b/apps/utils/__init__.py
@@ -1,1 +1,2 @@
+from apps.utils.permissions import IsOwnerOrReadOnly
 from apps.utils.timestamp import TimeStampedModel

--- a/apps/utils/permissions.py
+++ b/apps/utils/permissions.py
@@ -1,0 +1,15 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsOwnerOrReadOnly(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+
+        if request.user.is_authenticated:
+            if request.user.is_admin:
+                return True
+            elif request.user.id == obj.id:
+                return True
+            else:
+                return False

--- a/config/settings.py
+++ b/config/settings.py
@@ -171,3 +171,21 @@ CORS_ALLOW_HEADERS = (
     "x-csrftoken",
     "x-requested-with",
 )
+
+# Log
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+        }
+    },
+    "loggers": {
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+        },
+    },
+}


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- 회원정보 수정, 삭제 기능을 구현합니다.

### Changes

api/v1/accounts/<int:pk>
- GET : 유저 정보 조회 (누구나 접근 가능)
- PUT : 유저 정보 수정 (해당 계정 소유자)
- DELETE :  유저 회원 비활성화 (soft delete) (해당 계정 소유자)

### 특이사항 (Optional)

<img width="574" alt="스크린샷 2022-08-01 오후 11 48 11" src="https://user-images.githubusercontent.com/83942213/182176691-46f1d71c-2274-4cb8-a782-c9b3c4be81d8.png">
soft delete 로직이 추가되면서 로그인시에 validation을 추가했습니다.

### Screenshots (Optional)

- GET 호출시
<img width="2112" alt="회원정보 변경 (GET)" src="https://user-images.githubusercontent.com/83942213/182174044-36aa37d4-09d1-4b0f-8c6d-b0fee7c06129.png">

<br>
<br>

- PUT 호출시 validation error 
<img width="2120" alt="회원정보 변경 (PUT) validatation error" src="https://user-images.githubusercontent.com/83942213/182174257-11f319c9-8661-4f93-a98d-31824dcc56dc.png">
unique 값인 account_name이 이미 존재시

<br>
<br>

- PUT 호출 성공
<img width="2106" alt="회원정보 변경 (PUT) 성공" src="https://user-images.githubusercontent.com/83942213/182174603-27fed046-2e8f-4010-b3a0-a8bcb90ce2f3.png">
기존 12 -> edited_12로 변경

<br>
<br>

- DELETE 호출 성공
<img width="2106" alt="회원정보 변경(DELETE) 호출완료" src="https://user-images.githubusercontent.com/83942213/182174934-b320bd54-e77d-4978-b718-90635089bbfa.png">
account의 is_active 필드를 False(default=True) 변경

<br>
<br>

- DELETE 후 API 호출시 
<img width="2117" alt="회원정보 변경(DELETE) 완료 후 API 호출시 에러" src="https://user-images.githubusercontent.com/83942213/182175156-1e474def-4fbf-4229-b3a7-b676642c795a.png">
계정의 is_active 필드가 False로 변경함으로써 계정은 비활성화됩니다.

<br>
<br>

- DELETE가 된 계정 GET으로 호출시
<img width="2117" alt="회원정보 변경(GET) 비활성화된 계정 호출시" src="https://user-images.githubusercontent.com/83942213/182175509-c2fce2cc-e763-4ec6-995f-0bb45ddfcc0e.png">
비활성화 (soft delete) 된 계정을 GET으로 호출시

<br>