### PR TITLE
[Feat] 게시물 목록조회 (#34)

### DIFF
--- a/apps/post/serializers.py
+++ b/apps/post/serializers.py
@@ -1,4 +1,4 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
 from apps.post.models import Post, Tag
 
@@ -33,6 +33,28 @@ class PostCreateSerializer(ModelSerializer):
             "title",
             "content",
             "tags",
+            "created_at",
+        ]
+        extra_kwargs = {"id": {"read_only": True}}
+
+
+class PostListSerializer(ModelSerializer):
+
+    writer = SerializerMethodField()
+    tags = TagSerializer(many=True)
+
+    def get_writer(self, obj):
+        return obj.writer.account_name
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "writer",
+            "title",
+            "content",
+            "tags",
+            "views",
             "created_at",
         ]
         extra_kwargs = {"id": {"read_only": True}}

--- a/apps/post/views.py
+++ b/apps/post/views.py
@@ -1,9 +1,11 @@
+from django.db.models import Q
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.post.serializers import PostCreateSerializer
+from apps.post.models import Post
+from apps.post.serializers import PostCreateSerializer, PostListSerializer
 
 
 # api/v1/posts
@@ -19,3 +21,38 @@ class PostView(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         else:
             return Response({"message": "게시글 작성에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+    def get(self, request):
+        try:
+            search = request.GET.get("search", None)
+            tag = request.GET.get("tag", None)
+            sort = request.GET.get("sort", "recent")
+            offset = int(request.GET.get("offset", 0))
+            limit = int(request.GET.get("limit", 10))
+
+            q = Q()
+
+            if search:
+                q |= Q(title__icontains=search)
+                q |= Q(content__icontains=search)
+
+            if tag:
+                tags = tag.split(",")
+                q &= Q(tags__name__in=tags)
+
+            sort_set = {
+                "recent": "-created_at",
+                "most_viewed": "-views",
+            }
+
+            posts = (
+                Post.objects.exclude(is_deleted=True)
+                .select_related("writer")
+                .prefetch_related("tags")
+                .filter(q)
+                .order_by(sort_set[sort])[offset : offset + limit]
+            )
+            serializer = PostListSerializer(posts, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except KeyError:
+            return Response({"message": "Key error"})


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- Q객체를 사용해 게시물 목록조회를 기능을 구현합니다.

### Changes

- 


### 특이사항 (Optional)

- 

### Screenshots (Optional)

<img width="595" alt="스크린샷 2022-08-18 오전 1 09 01" src="https://user-images.githubusercontent.com/83942213/185189266-ee0ef0f1-af3a-4a26-b28f-e93d6ebc2cba.png">

<img width="2119" alt="스크린샷 2022-08-18 오전 1 00 06" src="https://user-images.githubusercontent.com/83942213/185191008-ab69c73e-6382-49f9-8661-ed9536a96451.png">

- search는 게시물의 제목(title)과 내용(content) 중 "한가지라도 검색어에 충족한다면" 검색됩니다.
- tag는 ","를 분기로 중복으로 필터가 가능합니다.
- sort(정렬)은 recent -> 최신게시순, most_viewed -> 조회수 높은순으로 정렬이 가능합니다.
- 페이지네이션을 위한 offset, limit값의 offset 기본값은 10입니다.