### PR TITLE
[Feat] 게시물 단건 상세조회, 수정, 삭제, 복구 (#36)

### DIFF
--- a/apps/account/permissions.py
+++ b/apps/account/permissions.py
@@ -1,0 +1,19 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsOwnerOrReadOnly(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+
+        if not user.is_active:
+            return False
+        if user.is_admin:
+            return True
+        if request.method in SAFE_METHODS:
+            return True
+
+        if user.is_authenticated:
+            if user.id == obj.id:
+                return True
+            else:
+                return False

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -7,13 +7,13 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from apps.account.models import Account
+from apps.account.permissions import IsOwnerOrReadOnly
 from apps.account.serializers import (
     AccountDeleteSerializer,
     AccountDetailSerializer,
     SignInSerializer,
     SignUpSerializer,
 )
-from apps.utils import IsOwnerOrReadOnly
 
 
 # api/v1/accounts/signup

--- a/apps/post/permissions.py
+++ b/apps/post/permissions.py
@@ -3,15 +3,17 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 class IsOwnerOrReadOnly(BasePermission):
     def has_object_permission(self, request, view, obj):
-        if not request.user.is_active:
+        user = request.user
+
+        if not user.is_active:
             return False
+        if user.is_admin:
+            return True
         if request.method in SAFE_METHODS:
             return True
 
-        if request.user.is_authenticated:
-            if request.user.is_admin:
-                return True
-            elif request.user.id == obj.id:
+        if user.is_authenticated:
+            if user.id == obj.writer.id:
                 return True
             else:
                 return False

--- a/apps/post/serializers.py
+++ b/apps/post/serializers.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
 from apps.post.models import Post, Tag
@@ -9,6 +12,7 @@ class TagSerializer(ModelSerializer):
         fields = ["name"]
 
 
+# api/v1/posts
 class PostCreateSerializer(ModelSerializer):
 
     tags = TagSerializer(many=True)
@@ -38,6 +42,7 @@ class PostCreateSerializer(ModelSerializer):
         extra_kwargs = {"id": {"read_only": True}}
 
 
+# api/v1/posts
 class PostListSerializer(ModelSerializer):
 
     writer = SerializerMethodField()
@@ -56,5 +61,95 @@ class PostListSerializer(ModelSerializer):
             "tags",
             "views",
             "created_at",
+        ]
+        extra_kwargs = {"id": {"read_only": True}}
+
+
+# api/v1/posts/<int:pk>
+class PostDetailSerializer(ModelSerializer):
+
+    tags = TagSerializer(many=True)
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "writer",
+            "title",
+            "content",
+            "tags",
+            "views",
+            "updated_at",
+        ]
+        extra_kwargs = {"id": {"read_only": True}}
+
+
+# api/v1/posts/<int:pk>
+class PostUpdateSerializer(ModelSerializer):
+
+    tags = TagSerializer(many=True)
+
+    def update(self, instance, validated_data):
+        instance.title = validated_data.get("title", instance.title)
+        instance.content = validated_data.get("content", instance.content)
+        instance.save()
+
+        tags = validated_data.pop("tags", None)
+        if tags:
+            instance.tags.clear()
+            for i in tags:
+                tag, _ = Tag.objects.get_or_create(name=i["name"])
+                instance.tags.add(tag)
+            instance.save()
+        return instance
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "title",
+            "content",
+            "tags",
+            "updated_at",
+        ]
+        extra_kwargs = {"id": {"read_only": True}}
+
+
+# api/v1/posts/<int:pk>
+class PostDeleteSerializer(ModelSerializer):
+    def update(self, instance, validated_data):
+        if instance.is_deleted:
+            raise serializers.ValidationError("이미 삭제된 게시물입니다.")
+        instance.is_deleted = True
+        instance.deleted_at = datetime.now()
+        instance.save()
+        return instance
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "is_deleted",
+            "deleted_at",
+        ]
+        extra_kwargs = {"id": {"read_only": True}}
+
+
+# api/v1/posts/<int:pk>
+class PostRestoreSerializer(ModelSerializer):
+    def update(self, instance, validated_data):
+        if not instance.is_deleted:
+            raise serializers.ValidationError("삭제되지 않은 게시물입니다.")
+        instance.is_deleted = False
+        instance.deleted_at = None
+        instance.save()
+        return instance
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "is_deleted",
+            "deleted_at",
         ]
         extra_kwargs = {"id": {"read_only": True}}

--- a/apps/post/urls.py
+++ b/apps/post/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from apps.post.views import PostView
+from apps.post.views import PostDetailView, PostView
 
 urlpatterns = [
     path("", PostView.as_view()),
+    path("/<int:pk>", PostDetailView.as_view()),
 ]

--- a/apps/utils/__init__.py
+++ b/apps/utils/__init__.py
@@ -1,2 +1,1 @@
-from apps.utils.permissions import IsOwnerOrReadOnly
 from apps.utils.timestamp import TimeStampedModel


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- 게시물 (단건) 상세 조회, 수정, 삭제, 복구 기능
- api/v1/posts/<int:pk>

- GET - 상세 조회, 인증 된 모든 회원 조회 가능, 조회시 조회수(views) 1 상승
- PATCH - 수정, 작성자 본인의 게시물만 수정 가능
- DELETE - 삭제 (상태 변경), 작성자 본인의 게시물만 삭제 가능
- PUT - 삭제 복구 (상태 변경), 작성자 본인의 게시물만 복구 가능

### Changes

-


### 특이사항 (Optional)

- apps-utils에서 사용하던 커스텀 permission 삭제 후 각 app들의 디렉토리에 새로 생성 

### Screenshots (Optional)

- GET 호출 성공
<img width="2120" alt="게시물 상세조회 GET" src="https://user-images.githubusercontent.com/83942213/185409877-858cacfb-f314-4535-9b00-cd223ac94887.png">

- PATCH 호출 성공
<img width="2137" alt="게시물 수정 PATCH 성공" src="https://user-images.githubusercontent.com/83942213/185409985-4bc7a5ca-e906-4819-8daf-84b8a3134507.png">

- DELETE 호출 성공
<img width="2128" alt="게시물 상태변경 DELETE 성공" src="https://user-images.githubusercontent.com/83942213/185410075-d271c92a-b7e7-4dd2-9a32-744990521f9c.png">

- DELETE 호출 실패
<img width="2128" alt="게시물 상태변경 DELETE 실패 (이미 삭제)" src="https://user-images.githubusercontent.com/83942213/185410270-521ff332-cb2f-4152-8e74-d1874e328ffb.png">

- PUT 호출 성공
<img width="2128" alt="게시물 삭제복구 PUT 성공" src="https://user-images.githubusercontent.com/83942213/185410148-c9cb9388-9857-4dc6-b7da-1ae823fc0f90.png">

- PUT 호출 실패
<img width="2126" alt="게시물 삭제복구 PUT 실패 (삭제되지않음)" src="https://user-images.githubusercontent.com/83942213/185410347-a8bebe8b-7611-4c4d-80dc-e11708e3c350.png">

- 공통 ( permission denied )
<img width="2125" alt="게시물 수정 PATCH 권한제어" src="https://user-images.githubusercontent.com/83942213/185410516-1ee8a853-46aa-4233-bb75-3add02c8678d.png">

(2번 유저가 1번유저의 게시글 1번을 수정 호출시)