### PR TITLE
[Refactor] 계정정보수정 API method 변경 (#38)

### DIFF
--- a/apps/account/serializers.py
+++ b/apps/account/serializers.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 
 from rest_framework import serializers
+from rest_framework.serializers import ModelSerializer
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from apps.account.models import Account
 
 
 # api/v1/accounts/signup
-class SignUpSerializer(serializers.ModelSerializer):
+class SignUpSerializer(ModelSerializer):
     def create(self, validated_data):
         account = Account.objects.create_user(**validated_data)
         account.set_password(validated_data.get("password"))
@@ -60,7 +61,7 @@ class SignInSerializer(TokenObtainPairSerializer):
 
 
 # api/v1/accounts/<int:pk>
-class AccountDetailSerializer(serializers.ModelSerializer):
+class AccountDetailSerializer(ModelSerializer):
     def validate(self, data):
         account_name = data.get("account_name")
 
@@ -89,7 +90,7 @@ class AccountDetailSerializer(serializers.ModelSerializer):
 
 
 # api/v1/accounts/<int:pk>
-class AccountDeleteSerializer(serializers.ModelSerializer):
+class AccountDeleteSerializer(ModelSerializer):
     def update(self, instance, validated_data):
         if not instance.is_active:
             raise serializers.ValidationError("이미 비활성화된 유저입니다.")

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -69,7 +69,7 @@ class AccountView(RetrieveUpdateAPIView):
     def get_serializer_class(self):
         if self.request.method == "GET":
             return AccountDetailSerializer
-        elif self.request.method == "PUT":
+        elif self.request.method == "PATCH":
             return AccountDetailSerializer
         elif self.request.method == "DELETE":
             return AccountDeleteSerializer
@@ -78,8 +78,14 @@ class AccountView(RetrieveUpdateAPIView):
         serializer = self.get_serializer(self.get_object())
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    def put(self, request, *args, **kwargs):
+    """
+    inherited from RetrieveUpdateAPIView
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
         return self.partial_update(request, *args, **kwargs)
+    """
 
     def delete(self, request, *args, **kwargs):
         return self.partial_update(request, *args, **kwargs)
@@ -101,11 +107,12 @@ class AccountRestoreView(APIView):
                 raise exceptions.ValidationError("잘못된 접근입니다")  # 활성화중인 계정
 
             if not account.check_password(password):
-                raise exceptions.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")  # 비밀번호 틀림
+                raise exceptions.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")
         else:
-            raise exceptions.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")  # 아이디 없음
+            raise exceptions.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")
 
         account.is_active = True
+        account.deleted_at = None
         account.save()
         return Response({"message": "계정이 활성화되었습니다."}, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [x] 리팩토링

### Summary

- 계정정보수정 API의 HTTP Method PUT -> PATCH 변경
- 회원탈퇴 복구시 account의 deleted_at 컬럼 None으로 변경되도록 수정

### Changes

- 


### 특이사항 (Optional)

-

### Screenshots (Optional)
