### PR TITLE
Refactor : 계정 삭제, 게시물 삭제 복구 HTTP Method 변경 (#42)

### DIFF
--- a/apps/account/serializers.py
+++ b/apps/account/serializers.py
@@ -35,7 +35,7 @@ class SignInSerializer(TokenObtainPairSerializer):
             account = Account.objects.get(email=email)
 
             if not account.is_active:
-                raise serializers.ValidationError("비활성화된 계정입니다.")
+                raise serializers.ValidationError("삭제된 계정입니다.")
 
             if not account.check_password(password):
                 raise serializers.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")  # 비밀번호 틀림

--- a/apps/account/urls.py
+++ b/apps/account/urls.py
@@ -2,10 +2,12 @@ from django.urls import path
 
 from apps.account.views import AccountRestoreView, AccountView, KakaoSignInView, SignInView, SignUpView
 
+app_name = "account"
+
 urlpatterns = [
-    path("/signup", SignUpView.as_view()),
-    path("/signin", SignInView.as_view()),
-    path("/kakao/signin", KakaoSignInView.as_view()),
-    path("/restore", AccountRestoreView.as_view()),
-    path("/<int:pk>", AccountView.as_view()),
+    path("/signup", SignUpView.as_view(), name="account_signup"),
+    path("/signin", SignInView.as_view(), name="account_signin"),
+    path("/kakao/signin", KakaoSignInView.as_view(), name="account_signin_kakao"),
+    path("/<int:pk>", AccountView.as_view(), name="account_detail"),
+    path("/restore", AccountRestoreView.as_view(), name="account_restore"),
 ]

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -96,7 +96,7 @@ class AccountRestoreView(APIView):
 
     permission_classes = [AllowAny]
 
-    def put(self, request):
+    def patch(self, request):
         email = request.data.get("email")
         password = request.data.get("password")
 
@@ -104,7 +104,7 @@ class AccountRestoreView(APIView):
             account = Account.objects.get(email=email)
 
             if account.is_active:
-                raise exceptions.ValidationError("잘못된 접근입니다")  # 활성화중인 계정
+                raise exceptions.ValidationError("잘못된 접근입니다")  # 삭제되지 않은 계정
 
             if not account.check_password(password):
                 raise exceptions.ValidationError("아이디 또는 비밀번호를 잘못 입력했습니다.")

--- a/apps/post/urls.py
+++ b/apps/post/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
 
-from apps.post.views import PostDetailView, PostView
+from apps.post.views import PostDetailView, PostRestoreView, PostView
+
+app_name = "post"
 
 urlpatterns = [
-    path("", PostView.as_view()),
-    path("/<int:pk>", PostDetailView.as_view()),
+    path("", PostView.as_view(), name="post"),
+    path("/<int:pk>", PostDetailView.as_view(), name="post_detail"),
+    path("/<int:pk>/restore", PostRestoreView.as_view(), name="post_restore"),
 ]


### PR DESCRIPTION
### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [x] 리팩토링

### Summary

- 계정 삭제 복구, 게시물 삭제 복구 HTTP Method 변경 ( PUT -> PATCH )
- 게시물 삭제 복구 endpoint 수정 ( api/v1/posts/<int:pk> -> api/v1/posts/<int:pk>/restore )

### Changes

- 


### 특이사항 (Optional)

- 두가지의 삭제 기능이 soft-delete로 진행되었기때문에 account는 is_active, post는 is_deleted 컬럼 (boolean)을 변경하고,
(공통으로) 삭제시 deleted_at을 현재시간으로 추가, 삭제시 해당 컬럼을 비우는 로직이였습니다.

CRUD의 U에 해당하는 update행위시에는 PUT보다 PATCH가 적절하다고 판단해 메소드를 수정합니다.

- 변경된 로직들에 대한 Readme의 API호출 테스트 스크린샷도 최신화 하였습니다.

### Screenshots (Optional)
